### PR TITLE
EPIC-1095 SCSS Modularization  / Add ng-page-scroll module

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "angular-esri-loader": "^1.1.0",
     "core-js": "^2.4.1",
     "mygovbc-bootstrap-theme": "^0.3.0",
+    "ng2-page-scroll": "^4.0.0-beta.9",
     "ngx-pagination": "^3.0.1",
     "rxjs": "^5.4.1",
     "typescript": "2.4.0",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -59,35 +59,7 @@
 	</nav>
 </header>
 
-<router-outlet>
-
-</router-outlet>
-
-	<!--
-	<div id="pad">
-		<nav>
-			<ul>
-				<li><a href="/" [routerLink]="['/']">Home</a></li>
-				<li><a href="/project" [routerLink]="['/project']">Project</a></li>
-				<li><a href="/news" [routerLink]="['/news']">News</a></li>
-			</ul>
-		</nav>
-
-		<div class="container">
-			<router-outlet>
-				<div *ngIf="recentNews">
-					<h1>Recent News</h1>
-					<div class="list-group table-of-contents">
-						<div *ngFor="let p of recentNews" class="list-group-item">
-							<div class="list-group-item">{{p.id}}</div>
-							<div class="">{{p.headline}}</div>
-						</div>
-					</div>
-				</div>
-			</router-outlet>
-		</div>
-	</div>
-	-->
+<router-outlet id="scrollTop"></router-outlet>
 
 <footer class="app-footer">
 	<div class="container">
@@ -172,4 +144,9 @@
 	</div>
 </footer>
 
-<button class="btn scroll-top-btn" (click)="scrollToTop()"><i class="material-icons">arrow_upward</i></button>
+<a href="#scrollTop" class="btn scroll-top-btn" 
+	pageScroll 
+	[pageScrollOffset]="0" 
+	[pageScrollDuration]="800">
+	<i class="material-icons">arrow_upward</i>
+</a>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { HomeComponent } from './home/home.component';
 import { ProjectService } from './services/project.service';
 import { EmailService } from './services/email.service';
 import { NewsService } from './services/news.service';
+import { PageScrollConfig } from 'ng2-page-scroll';
 
 import { News } from './models/news';
 import { ProjectComponent } from './project/project.component';
@@ -20,10 +21,23 @@ export class AppComponent implements OnInit {
   constructor(private newsService: NewsService, private _router: Router) {
     // Used for sharing links.
     this.hostname = encodeURI(window.location.href.replace(/\/$/, ''));
-  }
 
-  scrollToTop() {
-    window.scrollTo(0, 0);
+    PageScrollConfig.defaultScrollOffset = 50;
+    PageScrollConfig.defaultEasingLogic = {
+      ease: (t: number, b: number, c: number, d: number): number => {
+        // easeInOutExpo easing
+        if (t === 0) {
+          return b;
+        }
+        if (t === d) {
+          return b + c;
+        }
+        if ((t /= d / 2) < 1) {
+          return c / 2 * Math.pow(2, 8 * (t - 1)) + b;
+        }
+        return c / 2 * (-Math.pow(2, -8 * --t) + 2) + b;
+      }
+    };
   }
 
   ngOnInit() {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { ComplianceOversightComponent } from './compliance-oversight/compliance-
 import { ContactComponent } from './contact/contact.component';
 import { ContactSuccess } from './contact/contact.success';
 import { MapModule } from './map/map.module';
+import { Ng2PageScrollModule } from 'ng2-page-scroll';
 
 @NgModule({
   declarations: [
@@ -43,6 +44,7 @@ import { MapModule } from './map/map.module';
     HttpModule,
     AppRoutingModule,
     AlertModule.forRoot(),
+    Ng2PageScrollModule.forRoot(),
     NgbModule,
     NgxPaginationModule,
     MapModule

--- a/src/app/contact/contact.component.html
+++ b/src/app/contact/contact.component.html
@@ -66,21 +66,21 @@
                 </section>
             </main>
             <aside class="col-lg-4">
-                <section>
-                    <h4>Contact the EAO</h4>
-                    <div class="aside-section-body">
+                <section class="card">
+                    <h4 class="card-header">Contact the EAO</h4>
+                    <div class="card-body">
                         <p class="mb-0">Please use the <a href="https://dir.gov.bc.ca/gtds.cgi?show=Branch&organizationCode=ENV&organizationalUnitCode=ENVIRON5" target="_blank">EAO B.C. Government Directory</a> listing to find contact information for specific Environmental Assessment Office staff.</p>
                     </div>
                 </section>
-                <section>
-                    <h4>Compliance Oversight</h4>
-                    <div class="aside-section-body">
+                <section class="card">
+                    <h4 class="card-header">Compliance Oversight</h4>
+                    <div class="card-body">
                         <p class="mb-0">For questions about compliance, or if you have information about possible non-compliance with an environmental assessment certificate, please email <a href="">eao.compliance@gov.bc.ca</a>.</p>
                     </div>
                 </section>
-                 <section>
-                    <h4>Report Natural Resource Violoations</h4>
-                    <div class="aside-section-body">
+                <section class="card mb-0">
+                    <h4 class="card-header">Report Natural Resource Violoations</h4>
+                    <div class="card-body">
                         <p class="mb-0">Everyone has a role in protecting British Columbia’s natural resources. If you have seen misconduct involving wildlife, ecosystems, heritage sites or natural resources, you can report it <a href="http://www2.gov.bc.ca/gov/content/environment/natural-resource-stewardship/natural-resource-law-enforcement/report-natural-resource-violations" target="_blank">here</a>.</p>
                     </div>
                 </section>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -30,7 +30,7 @@
 								<span class="news-date">{{item.dateAdded | date}}</span>
 								<p>{{item.content}}</p>
 								<div class="news-block-btns">
-									<a class="btn inverted" href="#" ng-if="activity.projectLink">View Project</a>
+									<a class="btn inverted" href="https://projects.eao.gov.bc.ca/p/{{item.project.code}}/detail" ng-if="activity.projectLink">View Project</a>
 								</div>
 							</div>
 						</div>
@@ -40,7 +40,7 @@
 			<div class="row">
 				<div class="col-sm-12">
 					<div class="news-block-more">
-						<a href="/news" [routerLink]="['/news']">View all Activities & Updates &rsaquo;</a>
+						<a class="bg-dark-link" href="/news" [routerLink]="['/news']">View all Activities & Updates &rsaquo;</a>
 					</div>
 				</div>
 			</div>

--- a/src/app/news/news.component.scss
+++ b/src/app/news/news.component.scss
@@ -1,7 +1,9 @@
+@import "~assets/styles/base.scss";
+$news-block-border-color: #5475a7;
 
 .news-block {
     padding: 2.5rem 0;
-    border-top: 2px solid #5475a7;
+    border-top: 2px solid $bg-dark-border-color;
 
     h3 {
         margin-bottom: 0.2rem;
@@ -33,14 +35,13 @@
         .btn {
             margin-right: 0.25rem;
             font-size: 0.85rem;
-            //border-color: #5475a7;
         }
     }
 }
 
 .news-block-more {
     padding-top: 2rem;
-    border-top: 3px solid #5475a7;
+    border-top: 3px solid $bg-dark-border-color;
 
     a {
         font-weight: 600;

--- a/src/assets/js/utils.js
+++ b/src/assets/js/utils.js
@@ -5,7 +5,7 @@ function scroll_style() {
     if (div_top.length) {
         var anchorPoint = div_top.offset().top;
 
-        if (window_top > anchorPoint - 450) {
+        if (window_top > anchorPoint - 350) {
             $("#header").addClass("dark");
         } else {
             $("#header").removeClass("dark");

--- a/src/assets/styles/base.scss
+++ b/src/assets/styles/base.scss
@@ -1,0 +1,2 @@
+@import "~assets/styles/helpers/mixins.scss";
+@import "~assets/styles/themes/default.scss";

--- a/src/assets/styles/components/aside.scss
+++ b/src/assets/styles/components/aside.scss
@@ -1,33 +1,23 @@
-
-$aside-section-head-color: #fff;
-$aside-section-head-bg: #38598a;
+@import "~assets/styles/base.scss";
 
 aside {
     section {
         margin-bottom: 1.5rem;
 
-        h4 {
-            margin: 0;
-            padding: 0.65rem 1rem;
-            color: $aside-section-head-color;
-            background: $aside-section-head-bg;
+        h5 {
+            color: $aside-title-color;
             text-transform: uppercase;
             font-size: 0.9375rem;
-            font-weight: bold;
+            font-weight: 700;
         }
 
-        .aside-section-body {
-            padding: 1rem;
-            background: #f7f8fa;
-
-            p {
-                line-height: 1.45rem;
-                font-size: 0.9375rem;
-            }
-
-            a {
-                text-decoration: underline;
-            }
+        p {
+            font-size: 0.9375rem;
+            line-height: 1.4rem;
         }
+    }
+
+    .card-body {
+        background: $aside-bg;
     }
 }

--- a/src/assets/styles/components/buttons.scss
+++ b/src/assets/styles/components/buttons.scss
@@ -1,3 +1,4 @@
+@import "~assets/styles/base.scss";
 
 .btn {
     border-radius: 0.25rem;
@@ -7,10 +8,9 @@
     transition: all linear 0.2s;
 
     &.inverted {
+        color: #fff;
         border: 2px solid #fff;
         background: transparent;
-        //text-shadow: 1px 1px 1px #fdd165;
-        color: #fff;
 
         &:active,
         &:focus,

--- a/src/assets/styles/components/card.scss
+++ b/src/assets/styles/components/card.scss
@@ -1,0 +1,19 @@
+@import "~assets/styles/base.scss";
+
+.card {
+    border: none;
+}
+
+.card-header {
+    padding: 0.75rem 1rem;
+    color: $card-header-color;
+    background: $card-header-bg;
+    text-transform: uppercase;
+    font-size: 0.9375rem;
+    font-weight: 700;
+}
+
+.card-body {
+    border: none;
+    padding: 1rem;
+} 

--- a/src/assets/styles/components/feature-block.scss
+++ b/src/assets/styles/components/feature-block.scss
@@ -1,17 +1,18 @@
+@import "~assets/styles/base.scss";
 
 .feature-block {
     margin-bottom: 1rem;
     padding: 1.75rem 1rem;
     background-image: url("assets/images/hero-banner-placeholder.jpg");
     background-size: 200%;
-    background-color: #244278;
-    color: #FFF;
+    background-color: $feature-block-bg;
+    color: $feature-block-color;
     text-align: center;
 
     h3 {
         margin-top: 0;
         margin-bottom: 1rem;
-        color: #FFF;
+        color: inherit;
         font-size: 1.25rem;
         font-weight: 300;
     }

--- a/src/assets/styles/components/filter-bar.scss
+++ b/src/assets/styles/components/filter-bar.scss
@@ -1,3 +1,4 @@
+@import "~assets/styles/base.scss";
 
 .filter-bar {
     label {
@@ -12,7 +13,7 @@
 
     .form-control {
         &:focus {
-            border-color: #5091cd;
+            border-color: $fc-focus-border-color;
             z-index: 2;
         }
     }
@@ -47,7 +48,7 @@
             padding: 0.5rem;
             border-top-left-radius: 0;
             border-bottom-left-radius: 0;
-            border: 1px solid #ccc;
+            border: 1px solid $fc-border-color;
 
             i {
                 margin: 0;

--- a/src/assets/styles/components/form-elements.scss
+++ b/src/assets/styles/components/form-elements.scss
@@ -1,55 +1,46 @@
-
-// Default State
-$form-control-height: 2.75rem;
-$form-control-border-color: #ddd;
-$form-control-bg: #fff;
-$form-control-inner-shadow: 0.1rem 0.1rem 0.1rem #EEE;
-$form-control-placeholder-color: #ccc;
-
-// Focus State
-$form-control-focus-border-color: #5091cd;
+@import "~assets/styles/base.scss";
 
 .form-group {
 	margin-bottom: 2rem;
 }
 
 .form-control {
-	border-color: $form-control-border-color;
-    background-color: $form-control-bg;
+	border-color: $fc-border-color;
+    background-color: $fc-bg;
     font-size: 0.9375rem;
 
 	&:focus {
-		border-color: $form-control-focus-border-color;
+		border-color: $fc-focus-border-color;
 	}
 }
 
 input[type="text"] {
 	@include placeholder {
-		color: $form-control-placeholder-color
+		color: $fc-placeholder-color
 	}
-	height: $form-control-height;
+	height: $fc-height;
 	padding: 0.75rem;
-	box-shadow: $form-control-inner-shadow inset;
+	box-shadow: $fc-inner-shadow inset;
 }
 
 input[type="email"] {
 	@include placeholder {
-		color: $form-control-placeholder-color;
+		color: $fc-placeholder-color;
 	}
-	height: $form-control-height;
+	height: $fc-height;
 	padding: 0.75rem;
 }
 
 select.form-control:not([size]):not([multiple]) {
-	height: $form-control-height;
+	height: $fc-height;
 	padding: 0 0.5rem;
 }
 
 textarea {
 	@include placeholder {
-		color: $form-control-placeholder-color;
+		color: $fc-placeholder-color;
 	}
 	font-size: 0.9375rem;
 	resize: vertical;
-	box-shadow: $form-control-inner-shadow inset;
+	box-shadow: $fc-inner-shadow inset;
 }

--- a/src/assets/styles/components/hero-banner.scss
+++ b/src/assets/styles/components/hero-banner.scss
@@ -1,13 +1,9 @@
+@import "~assets/styles/base.scss";
 
 // Banner
 .hero-banner {
     background-image: url("assets/images/hero-banner-placeholder.jpg");
     background-repeat: no-repeat;
-
-    //&.banner-sample-1 {
-        //background-image: url("/modules/core/client/images/sample-bg-img-duotone-3.jpg");
-        //background-size: 100%;
-    //}
 }
 
 .hero-banner {

--- a/src/assets/styles/components/lists.scss
+++ b/src/assets/styles/components/lists.scss
@@ -1,0 +1,28 @@
+@import "~assets/styles/base.scss";
+
+.nv-list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+
+    li {
+        @include clearfix();
+        margin-top: 1px;
+        padding: 0.5rem 1rem;
+        font-size: 0.9375rem;
+        background: $nv-list-bg;
+    }
+
+    span {
+        &.name,
+        &.value {
+            float: left;
+            display: block;
+            width: 50%;
+        }
+
+        &.name {
+            margin-bottom: 0.25rem;
+        }
+    }
+}

--- a/src/assets/styles/components/pagination.scss
+++ b/src/assets/styles/components/pagination.scss
@@ -1,9 +1,4 @@
-
-$pgn-btn-bg: #eee;
-$pgn-btn-active-bg: #5091cd;
-$pgn-btn-active-color: #fff;
-$pgn-btn-border: 1px solid #ccc;
-$pgn-btn-color: #000;
+@import "~assets/styles/base.scss";
 
 pagination-template {
     @include flex-box();

--- a/src/assets/styles/components/table.scss
+++ b/src/assets/styles/components/table.scss
@@ -1,9 +1,4 @@
-$table-header-bg: #fff;
-$table-header-hover-bg: #ddd;
-$table-header-sort-active: #5091cd;
-$table-row-bg: #f7f8fa;
-$table-row-border: 3px solid #FFF;
-$table-alt-row-bg: #f4f4f4;
+@import "~assets/styles/base.scss";
 
 .table {
     width: 100%;

--- a/src/assets/styles/footer.scss
+++ b/src/assets/styles/footer.scss
@@ -1,3 +1,5 @@
+@import "~assets/styles/base.scss";
+
 footer {
     &.app-footer {
         border-top: 4px solid $gold;
@@ -13,7 +15,7 @@ footer {
         section {
             margin-bottom: 2rem;
             padding-bottom: 2rem;
-            border-bottom: 1px solid #5475a7;
+            border-bottom: 1px solid $bg-dark-border-color;
 
             &.last {
                 margin-bottom: 0;
@@ -65,24 +67,8 @@ footer {
         }
 
         .btn {
-            border-color: $gold;
-            color: $gold;
             font-size: 0.875rem;
             font-weight: 700;
-
-            &.inverted {
-                border: 2px solid #fff;
-                background: transparent;
-                color: #fff;
-
-                &:active,
-                &:focus,
-                &:hover {
-                    border-color: $gold;
-                    background: $gold;
-                    color: #002663;
-                }
-            }
         }
     }
 }
@@ -106,7 +92,7 @@ footer {
 
             h4 {
                 padding-bottom: 1.25rem;
-                border-bottom: 1px solid #5475a7;
+                border-bottom: 1px solid $bg-dark-border-color;
             }
         }
     }
@@ -115,7 +101,7 @@ footer {
 .footer-admin {
     margin-top: 2rem;
     padding-top: 1.5rem;
-    border-top: 1px solid #5475a7;
+    border-top: 1px solid $bg-dark-border-color;
     text-align: center;
 
     .gov-links {

--- a/src/assets/styles/header.scss
+++ b/src/assets/styles/header.scss
@@ -1,3 +1,4 @@
+@import "~assets/styles/base.scss";
 
 header {
     &.app-header {

--- a/src/assets/styles/helpers/helpers.scss
+++ b/src/assets/styles/helpers/helpers.scss
@@ -1,0 +1,10 @@
+@import "~assets/styles/base.scss";
+
+.bg-dark {
+    color: $bg-dark-color;
+    background-color: $bg-dark;
+}
+
+.bg-dark-link {
+    color: $bg-dark-link-color;
+}

--- a/src/assets/styles/helpers/mixins.scss
+++ b/src/assets/styles/helpers/mixins.scss
@@ -33,9 +33,9 @@
 }
 
 @mixin placeholder {
-    &::-webkit-input-placeholder {@content}
-    &:-moz-placeholder {@content}
-  	&::-moz-placeholder {@content}
-  	&:-ms-input-placeholder{@content}  
+    &::-webkit-input-placeholder {@content;}
+    &:-moz-placeholder {@content;}
+  	&::-moz-placeholder {@content;}
+  	&:-ms-input-placeholder{@content;}  
 }
 

--- a/src/assets/styles/helpers/typekit.scss
+++ b/src/assets/styles/helpers/typekit.scss
@@ -1,5 +1,0 @@
-
-// Fix the type flashing bug that occurs when page loads
-.wf-loading {
-    display: none;
-}

--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -1,3 +1,4 @@
+@import "~assets/styles/base.scss";
 
 // Container
 .container {
@@ -47,7 +48,7 @@ main {
 
     p {
         font-size: 1rem;
-        line-height: 1.65rem;
+        line-height: 1.8rem;
     }
 
     section {

--- a/src/assets/styles/themes/default.scss
+++ b/src/assets/styles/themes/default.scss
@@ -5,15 +5,26 @@ $gold:                          #fcba19;
 // Background Colors
 $bg-dark:                       #003366;
 $bg-dark-color:                 #FFF;
+$bg-dark-link-color:            $gold;
+$bg-dark-border-color:          #5475a7;
+
+// Font Colors
+$font-color:                    #494949;
+
+// Links
+$link-color:                    #1a5a96;
 
 // Header
 $header-font-color:             #FFF;
 $header-bg:                     $primary;
 
-// Main Navigation
-$mn-font-size: 0.875rem; //14px
-$mn-dropdown-menu-size: 0.875rem; //13px
+// Footer 
+$footer-bg:                     $primary;
+$footer-color:                  #FFF;
 
+// Main Navigation
+$mn-font-size:                  0.875rem; //14px
+$mn-dropdown-menu-size:         0.875rem; //13px
 $mn-color:                      #FFF;
 $mn-border-color:               #5f79a2;   
 $mn-hover-bg:                   #2b4777;
@@ -21,31 +32,45 @@ $mn-hover-color:                $gold;
 $mn-toggle-color:               $gold;
 $mn-dropdown-bg:                #2b4777;
 
-// Footer 
-$footer-bg:                     $primary;
-$footer-color:                  #FFF;
-
-// Typography
-$font-color:                    #494949;
-
-// Links
-$link-color:                    #1a5a96;
+// COMPONENTS
 
 // Aside
-$aside-title-bg:                #1a5a96;
-$aside-title-color:             #FFF;
-$aside-body-bg:                 #f1f1f1;
+$aside-title-color:             #38598a;
+$aside-bg:                      #f7f8fa;
+
+// Cards
+$card-header-color:             #fff;
+$card-header-bg:                #38598a;
+
+// Feature Blocks
+$feature-block-color:           #FFF;
+$feature-block-bg:              #244278;
+
+// Form Controls
+$fc-height:                     2.75rem;
+$fc-border-color:               #ddd;
+$fc-bg:                         #fff;
+$fc-inner-shadow:               0.1rem 0.1rem 0.1rem #EEE;
+$fc-placeholder-color:          #ccc;
+$fc-focus-border-color:         #5091cd;
+
+// List Variants
+$nv-list-bg:                    #f7f8fa;
+
+// Pagination Control
+$pgn-btn-bg:                    #eee;
+$pgn-btn-active-bg:             #5091cd;
+$pgn-btn-active-color:          #fff;
+$pgn-btn-border:                1px solid #ccc;
+$pgn-btn-color:                 #000;
+
+// Tables
+$table-header-bg:               #fff;
+$table-header-hover-bg:         #ddd;
+$table-header-sort-active:      #5091cd;
+$table-row-bg:                  #f7f8fa;
+$table-row-border:              3px solid #FFF;
+$table-alt-row-bg:              #f4f4f4;
 
 // Modal
 $modal-bg:                      #FFF;
-
-
-// Backgrounds
-.bg-dark {
-    color: #FFF;
-    background-color: $bg-dark;
-
-    a {
-        color: $gold;
-    }
-}

--- a/src/assets/styles/themes/typography.scss
+++ b/src/assets/styles/themes/typography.scss
@@ -1,4 +1,9 @@
 
+// Fix the type flashing bug that occurs when page loads
+.wf-loading {
+    display: none;
+}
+
 body {
     font-family: "myriad-pro";
     font-weight: 400;
@@ -14,7 +19,7 @@ h1 {
         display: block;
         letter-spacing: 0;
         line-height: normal;
-        font-size: 1.5rem;
+        font-size: 1.4rem;
         font-weight: 400;
     }
 }
@@ -37,14 +42,13 @@ h4 {
 p {
     margin-bottom: 1.75rem;
     font-size: 1rem;        //16px
-    line-height: 1.75rem;
+    line-height: 1.8rem;
 }
 
 a {
     color: #1a5a96;
 }
 
-// Controls / Form Components
 button, 
 input, 
 select, 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,11 +2,9 @@
 //@import "~mygovbc-bootstrap-theme/dist/mygovbc-bootstrap-theme.min.css";
 
 // Helpers
-@import "assets/styles/helpers/mixins.scss";
-@import "assets/styles/helpers/typekit.scss";
+@import "assets/styles/helpers/helpers.scss";
 
-// Theme
-@import "assets/styles/themes/default.scss";
+// Typography
 @import "assets/styles/themes/typography.scss";
 
 // Layout
@@ -17,14 +15,17 @@
 // Components
 @import "assets/styles/components/aside.scss";
 @import "assets/styles/components/buttons.scss";
+@import "assets/styles/components/card.scss";
 @import "assets/styles/components/feature-block.scss";
 @import "assets/styles/components/filter-bar.scss";
 @import "assets/styles/components/form-elements.scss";
 @import "assets/styles/components/hero-banner.scss";
+@import "assets/styles/components/lists.scss";
 @import "assets/styles/components/material-icons.scss";
 @import "assets/styles/components/pagination.scss";
 @import "assets/styles/components/spinner.scss";
 @import "assets/styles/components/table.scss";
+
 
 // Pages
 @import "app/news/news.component.scss";


### PR DESCRIPTION
Implementing modular strategy for SCSS files. All component styles will import BASE (mixins/helpers) so we can leverage independently from the global stylesheet (if needed).

- Added the "ng-page-scroll" module to support name anchors.
- Modified all component styles to include the BASE import
- Added additional component styles (cards, lists)