### PR TITLE
EPIC-1209 ArcGIS - prevent user from zooming too far out

### DIFF
--- a/src/app/map/config/map-config.ts
+++ b/src/app/map/config/map-config.ts
@@ -74,7 +74,14 @@ export const DEFAULT_MAP_CONFIG: MapConfig = {
         id: webmapForEnv()
       }
     },
-    mapView: {},
+    mapView: {
+      constraints: {
+        minZoom: 4,  // EPIC-1209 prevent user from zooming too far out
+      },
+      ui: {
+        components: ['attribution']
+      }
+    },
     popup: defaultPopupTemplate
   }
 };


### PR DESCRIPTION
* Add a limit boundary to how far out the user can zoom out the map
* Additionally, refactor the map loading sequence so the zoom control doesn't "jump" around. It is now positioned on the `bottom-right` corner from the beginning.