### PR TITLE
EPIC-1255 Upgrade to ArcGIS API v4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/platform-browser-dynamic": "^4.2.4",
     "@angular/router": "^4.2.4",
     "@ng-bootstrap/ng-bootstrap": "^1.0.0-alpha.26",
-    "angular-esri-loader": "^1.1.0",
+    "angular-esri-loader": "1.1.0",
     "bootstrap": "4.0.0-alpha.6",
     "core-js": "^2.4.1",
     "jquery": "^3.1.1",
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@angular/cli": "^1.1.3",
-    "@types/arcgis-js-api": "^4.5.0",
+    "@types/arcgis-js-api": "4.5.0",
     "@types/jasmine": "2.5.38",
     "@types/node": "~6.0.60",
     "codelyzer": "~2.0.0",

--- a/src/app/map/esri-map/esri-map.component.scss
+++ b/src/app/map/esri-map/esri-map.component.scss
@@ -1,5 +1,5 @@
 /* Required CSS for the ArcGIS API for JavaScript */
-@import url('https://js.arcgis.com/4.4/esri/css/main.css');
+@import url('https://js.arcgis.com/4.5/esri/css/main.css');
 @import "~assets/styles/base.scss";
 
 .map {

--- a/src/app/map/main-map/main-map.component.ts
+++ b/src/app/map/main-map/main-map.component.ts
@@ -91,7 +91,7 @@ export class MainMapComponent implements OnInit {
   }
 
   private setPopupTemplateForLayer(featureLayer: __esri.FeatureLayer, popupTemplate: __esri.PopupTemplateProperties): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       // the `esri/layers/FeatureLayer` instance is promise-based...
       // call the .then() method to execute code once the layer is ready
       return featureLayer.then(

--- a/src/app/map/map-loader.service.ts
+++ b/src/app/map/map-loader.service.ts
@@ -106,7 +106,7 @@ export class MapLoaderService {
   private loadArcgis(): Promise<Function> {
     return this.esriLoader.load({
       // use a specific version of the API instead of the latest
-      url: 'https://js.arcgis.com/4.4/'
+      url: 'https://js.arcgis.com/4.5/'
     });
   }
 }


### PR DESCRIPTION
Fixes the following 3rd-party bug:

**BUG-000104472:** Setting the `rotationEnabled` property of the MapView's constraints property to 'false'
no longer causes problems using pinch while zooming in/out on mobile devices.