### PR TITLE
Fixed spacing in Google Analytics tracking script

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'UA-92287050-2', { 'anonymize_ip': true });
+    gtag('config', 'UA-92287050-2', {'anonymize_ip':true});
   </script>
 </head>
 <body id="top">


### PR DESCRIPTION
Removed extra spacing from parameter specifications in GA tracking script.