### PR TITLE
em-820 update hrefs to use new documentUrl, contentUrl, and public project url

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -21,7 +21,7 @@
 		<section class="container">
 			<h2>Project Activities & Updates</h2>
 			<div class="home-news-feed">
-				
+
 				<div class="spinner-container" *ngIf="!results">
 					<div class="spinner-new rotating"></div>
 				</div>
@@ -44,7 +44,7 @@
 								</div>
 								<div class="activity-feed__actions">
 									<a class="btn btn-sm content-btn-alt" title="View more information about {{item.project.name}}"
-										href="{{hostname}}/p/{{item.project?.code}}/detail"
+										href="/p/{{item.project?.code}}"
 										*ngIf="item.project?.code" >
 										Project Info
 									</a>

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -52,4 +52,33 @@ describe('HomeComponent', () => {
       expect('component.results').toBeTruthy;
     });
   });
+  describe('setDocumentUrl', () => {
+    it('should set results.documentUrl to \'\' when given no document url', () => {
+      const data = [
+        {
+          documentUrl: ''
+        }
+      ];
+      component.setDocumentUrl(data);
+      expect(data[0].documentUrl).toBe('');
+    });
+    it('should not change results.documentUrl when given a www url', () => {
+      const data = [
+        {
+          documentUrl: 'http://www.test.com'
+        }
+      ];
+      component.setDocumentUrl(data);
+      expect(data[0].documentUrl).toBe('http://www.test.com');
+    });
+    it('should set results.documentUrl to \'http://localhost:3000/blarg\' when given an esm-server document', () => {
+      const data = [
+        {
+          documentUrl: '/blarg'
+        }
+      ];
+      component.setDocumentUrl(data);
+      expect(data[0].documentUrl).toBe('http://localhost:3000/blarg');
+    });
+  });
 });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -15,9 +15,23 @@ export class HomeComponent implements OnInit {
 
   ngOnInit() {
     this.newsService.getRecentNews().subscribe(
-      data => { this.results = data; },
+      data => {
+        this.setDocumentUrl(data);
+        this.results = data;
+      },
       error => console.log(error)
     );
-    this.hostname = this.api.hostnameEPIC;
+  }
+
+  setDocumentUrl(data) {
+    const regex = /http(s)?:\/\/(www.)?/;
+    data.forEach(activity => {
+      if (!activity.documentUrl) {
+        return ;
+      }
+      if (!regex.test(activity.documentUrl)) {
+        activity.documentUrl = `${this.api.hostnameEPIC }${ activity.documentUrl }`;
+      }
+    });
   }
 }

--- a/src/app/models/news.ts
+++ b/src/app/models/news.ts
@@ -8,6 +8,8 @@ export class News {
   priority: number;
   type: string;
   dateUpdated: string;
+  contentUrl: string;
+  documentUrl: string;
   constructor(obj?: any) {
     this._id = obj && obj._id || null;
     this.headline = obj && obj.headline || null;
@@ -16,5 +18,7 @@ export class News {
     this.priority = obj && obj.priority || null;
     this.type = obj && obj.type || null;
     this.dateUpdated = obj && obj.dateUpdated || null;
+    this.contentUrl = obj && obj.contentUrl || null;
+    this.documentUrl = obj && obj.documentUrl || null;
   }
 }

--- a/src/app/news/news.component.html
+++ b/src/app/news/news.component.html
@@ -105,7 +105,7 @@
                   </button>
                 </div>
                 <div class="activity-feed__actions">
-                  <a class="btn btn-sm content-btn-alt" *ngIf="item.project?.code" href="{{hostname}}/p/{{item.project?.code}}/detail"
+                  <a class="btn btn-sm content-btn-alt" *ngIf="item.project?.code" href="/p/{{item.project?.code}}"
                     target="_blank">View Project</a>
                   <a class="btn btn-sm content-btn-alt" *ngIf="item.contentUrl" href="{{item.contentUrl}}" target="_blank">View Comments</a>
                   <a class="btn btn-sm content-btn-alt" *ngIf="item.documentUrl" href="{{item.documentUrl}}" target="_blank">View Document(s)</a>

--- a/src/app/news/news.component.spec.ts
+++ b/src/app/news/news.component.spec.ts
@@ -145,4 +145,33 @@ describe('NewsComponent', () => {
       expect(component.filterType).toBeFalsy;
     });
   });
+  describe('setDocumentUrl', () => {
+    it('should set results.documentUrl to \'\' when given no document url', () => {
+      const data = [
+        {
+          documentUrl: ''
+        }
+      ];
+      component.setDocumentUrl(data);
+      expect(data[0].documentUrl).toBe('');
+    });
+    it('should not change results.documentUrl when given a www url', () => {
+      const data = [
+        {
+          documentUrl: 'http://www.test.com'
+        }
+      ];
+      component.setDocumentUrl(data);
+      expect(data[0].documentUrl).toBe('http://www.test.com');
+    });
+    it('should set results.documentUrl to \'http://localhost:3000/blarg\' when given an esm-server document', () => {
+      const data = [
+        {
+          documentUrl: '/blarg'
+        }
+      ];
+      component.setDocumentUrl(data);
+      expect(data[0].documentUrl).toBe('http://localhost:3000/blarg');
+    });
+  });
 });

--- a/src/app/news/news.component.ts
+++ b/src/app/news/news.component.ts
@@ -34,6 +34,7 @@ export class NewsComponent implements OnInit {
     this.loading = true;
     this.newsService.getAll().subscribe(
       data => {
+        this.setDocumentUrl(data);
         this.results = data;
         this.loading = false;
         this.column = 'dateAdded';
@@ -43,7 +44,19 @@ export class NewsComponent implements OnInit {
       },
       error => console.log(error)
     );
-    this.hostname = this.api.hostnameEPIC;
+  }
+
+  setDocumentUrl(data) {
+    // attach host to document url if it goes to esm-server
+    const regex = /http(s)?:\/\/(www.)?/;
+    data.forEach(activity => {
+      if (!activity.documentUrl) {
+        return ;
+      }
+      if (!regex.test(activity.documentUrl)) {
+        activity.documentUrl = `${this.api.hostnameEPIC }${ activity.documentUrl }`;
+      }
+    });
   }
 
   sort (property) {

--- a/src/app/project-detail/project-detail.component.spec.ts
+++ b/src/app/project-detail/project-detail.component.spec.ts
@@ -182,4 +182,39 @@ describe('ProjectDetailComponent', () => {
       expect(router.navigate).toHaveBeenCalledWith(['/map', { project: component.project.code}]);
     });
   });
+  describe('setDocumentUrl', () => {
+    it('should set results.documentUrl to \'\' when no document url ', () => {
+      const data = {
+        recent_activities: [
+          {
+            documentUrl: ''
+          }
+        ]
+      };
+      component.setDocumentUrl(data);
+      expect(data.recent_activities[0].documentUrl).toBe('');
+    });
+    it('should not change results.documentUrl when given a www url', () => {
+      const data = {
+        recent_activities: [
+          {
+            documentUrl: 'http://www.test.com'
+          }
+        ]
+      };
+      component.setDocumentUrl(data);
+      expect(data.recent_activities[0].documentUrl).toBe('http://www.test.com');
+    });
+    it('should set results.documentUrl to \'http://localhost:3000/blarg\' when given an esm-server document ', () => {
+      const data = {
+        recent_activities: [
+          {
+            documentUrl: '/blarg'
+          }
+        ]
+      };
+      component.setDocumentUrl(data);
+      expect(data.recent_activities[0].documentUrl).toBe('http://localhost:3000/blarg');
+    });
+  });
 });

--- a/src/app/project-detail/project-detail.component.ts
+++ b/src/app/project-detail/project-detail.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Project } from '../models/project';
 import { Subscription } from 'rxjs/Subscription';
 import { PaginationInstance } from 'ngx-pagination';
+import { Api } from '../services/api';
 
 @Component({
   selector: 'app-project-detail',
@@ -30,7 +31,7 @@ export class ProjectDetailComponent implements OnInit {
 
   private sub: Subscription;
 
-  constructor(private _changeDetectionRef: ChangeDetectorRef, private route: ActivatedRoute, private router: Router) { }
+  constructor(private api: Api, private _changeDetectionRef: ChangeDetectorRef, private route: ActivatedRoute, private router: Router) { }
 
   ngOnInit() {
     this.loading = true;
@@ -38,6 +39,8 @@ export class ProjectDetailComponent implements OnInit {
       (data: { project: Project }) => {
         this.project = new Project(data.project);
         this.loading = false;
+        // attach host to document url if it goes to esm-server
+        this.setDocumentUrl(this.project);
 
         if (!this.project.proponent) {
           this.project.proponent = { name: '' };
@@ -49,6 +52,17 @@ export class ProjectDetailComponent implements OnInit {
       },
       error => console.log(error)
     );
+  }
+  setDocumentUrl(project) {
+    const regex = /http(s)?:\/\/(www.)?/;
+    project.recent_activities.forEach(activity => {
+      if (!activity.documentUrl) {
+        return ;
+      }
+      if (!regex.test(activity.documentUrl)) {
+        activity.documentUrl = `${this.api.hostnameEPIC }${ activity.documentUrl }`;
+      }
+    });
   }
   sort (property) {
     this.isDesc = !this.isDesc;


### PR DESCRIPTION
Change hrefs for the public project details page, the home page, and the news page to use the window's host as a host instead of hard coding it.

Did some url parsing to add window's host to front of url as long as documentUrl or projectUrl is a route and not a full url (doesn't include http://www).