### PR TITLE
em-948-fix: Add pagination reset to clear filters action.

### DIFF
--- a/src/app/news/news.component.spec.ts
+++ b/src/app/news/news.component.spec.ts
@@ -138,22 +138,28 @@ describe('NewsComponent', () => {
   });
 
   describe('clearAllNewsFilters()', () => {
-    it('should set filter to undefined', () => {
+    beforeEach(() => {
       component.filter = 'filtertest';
+      component.NewsTypeFilter = 'public comment period';
+      component.filterType = 'test';
+      component.config.currentPage = 100;
       component.clearAllNewsFilters();
-      expect(component.filter).toBeFalsy();
+    });
+
+    it('should set filter to undefined', () => {
+      expect(component.filter).toBeUndefined();
     });
 
     it('should set NewsTypeFilter to be undefined', () => {
-      component.NewsTypeFilter = '';
-      component.clearAllNewsFilters();
-      expect(component.NewsTypeFilter).toBeFalsy();
+      expect(component.NewsTypeFilter).toBeUndefined();
     });
 
     it('should set filterType to be undefined', () => {
-      component.filterType = 'test';
-      component.clearAllNewsFilters();
-      expect(component.filterType).toBeFalsy();
+      expect(component.filterType).toBeUndefined();
+    });
+
+    it('should set the current page to 1', () => {
+      expect(component.config.currentPage).toBe(1);
     });
   });
 

--- a/src/app/news/news.component.ts
+++ b/src/app/news/news.component.ts
@@ -18,7 +18,7 @@ export class NewsComponent implements OnInit {
   public showFilters: boolean;
   public projectFilter: boolean;
   public filter = '';
-  public NewsTypeFilter: '';
+  public NewsTypeFilter = '';
   public isDesc: boolean;
   public column: string;
   public direction: number;
@@ -76,6 +76,7 @@ export class NewsComponent implements OnInit {
     this.filter = undefined;
     this.NewsTypeFilter = undefined;
     this.filterType = undefined;
+    this.config.currentPage = 1;
   }
 
   readmore(item): void {

--- a/src/app/project-detail/project-detail.component.spec.ts
+++ b/src/app/project-detail/project-detail.component.spec.ts
@@ -216,22 +216,28 @@ describe('ProjectDetailComponent', () => {
   });
 
   describe('clearAllNewsFilters()', () => {
-    it('should set filter to undefined', () => {
+    beforeEach(() => {
       component.filter = 'filtertest';
+      component.NewsTypeFilter = 'news';
+      component.filterType = 'test';
+      component.config.currentPage = 100;
       component.clearAllNewsFilters();
-      expect(component.filter).toBeFalsy();
+    });
+
+    it('should set filter to undefined', () => {
+      expect(component.filter).toBeUndefined();
     });
 
     it('should set NewsTypeFilter to be undefined', () => {
-      component.NewsTypeFilter = '';
-      component.clearAllNewsFilters();
-      expect(component.NewsTypeFilter).toBeFalsy();
+      expect(component.NewsTypeFilter).toBeUndefined();
     });
 
     it('should set filterType to be undefined', () => {
-      component.filterType = 'test';
-      component.clearAllNewsFilters();
-      expect(component.filterType).toBeFalsy();
+      expect(component.filterType).toBeUndefined();
+    });
+
+    it('should set the current page to 1', () => {
+      expect(component.config.currentPage).toBe(1);
     });
   });
 

--- a/src/app/project-detail/project-detail.component.ts
+++ b/src/app/project-detail/project-detail.component.ts
@@ -26,7 +26,7 @@ export class ProjectDetailComponent implements OnInit {
   public showFilters: boolean;
   public projectFilter: boolean;
   public filter = '';
-  public NewsTypeFilter: '';
+  public NewsTypeFilter = '';
   public filterType = '';
 
   public config: PaginationInstance = {
@@ -95,6 +95,7 @@ export class ProjectDetailComponent implements OnInit {
     this.filter = undefined;
     this.NewsTypeFilter = undefined;
     this.filterType = undefined;
+    this.config.currentPage = 1;
   }
 
   gotoMap(): void {

--- a/src/app/project/project.component.spec.ts
+++ b/src/app/project/project.component.spec.ts
@@ -173,64 +173,63 @@ describe('ProjectComponent', () => {
   });
 
   describe('clearAllProjectFilters()', () => {
-    it('should set filter to undefined', () => {
+    beforeEach(() => {
       component.filter = 'filtertest';
+      component.projectTypeFilter = 'great type';
+      component.filterType = 'superfilter';
+      component.projectDecisionFilter = 'awesome decision';
+      component.filterDecision = 'filterD';
+      component.proponentListFilter = 'proponenT';
+      component.propfilter = 'test';
+      component.phasefilter = 'phase epsylon';
+      component.projectPhaseFilter = 'project gamma';
+      component.filterPCP = 'pcp for p in p';
+      component.config.currentPage = 100;
       component.clearAllProjectFilters();
-      expect(component.filter).toBeFalsy();
+    });
+
+    it('should set filter to undefined', () => {
+      expect(component.filter).toBeUndefined();
     });
 
     it('should set NewsTypeFilter to be undefined', () => {
-      component.projectTypeFilter = '';
-      component.clearAllProjectFilters();
-      expect(component.projectTypeFilter).toBeFalsy();
+      expect(component.projectTypeFilter).toBeUndefined();
     });
 
     it('should set filterType to be undefined', () => {
-      component.filterType = '';
-      component.clearAllProjectFilters();
-      expect(component.filterType).toBeFalsy();
+      expect(component.filterType).toBeUndefined();
     });
 
     it('should set projectDecisionFilter to be undefined', () => {
-      component.projectDecisionFilter = '';
-      component.clearAllProjectFilters();
-      expect(component.projectDecisionFilter).toBeFalsy();
+      expect(component.projectDecisionFilter).toBeUndefined();
     });
 
     it('should set filterDecision to be undefined', () => {
-      component.filterDecision = '';
-      component.clearAllProjectFilters();
-      expect(component.filterDecision).toBeFalsy();
+      expect(component.filterDecision).toBeUndefined();
     });
 
     it('should set proponentListFilter to be undefined', () => {
-      component.proponentListFilter = '';
-      component.clearAllProjectFilters();
-      expect(component.proponentListFilter).toBeFalsy();
+      expect(component.proponentListFilter).toBeUndefined();
     });
 
     it('should set propfilter to be undefined', () => {
-      component.propfilter = 'test';
-      component.clearAllProjectFilters();
-      expect(component.propfilter).toBeFalsy();
+      expect(component.propfilter).toBeUndefined();
     });
 
     it('should set phasefilter to be undefined', () => {
-      component.phasefilter = '';
-      component.clearAllProjectFilters();
-      expect(component.phasefilter).toBeFalsy();
+      expect(component.phasefilter).toBeUndefined();
     });
 
     it('should set projectPhaseFilter to be undefined', () => {
-      component.projectPhaseFilter = '';
-      component.clearAllProjectFilters();
-      expect(component.projectPhaseFilter).toBeFalsy();
+      expect(component.projectPhaseFilter).toBeUndefined();
     });
 
     it('should set filterPCP to be undefined', () => {
-      component.filterPCP = '';
-      component.clearAllProjectFilters();
-      expect(component.filterPCP).toBeFalsy();
+      expect(component.filterPCP).toBeUndefined();
+    });
+
+    it('should set the current page to 1', () => {
+      expect(component.config.currentPage).toBe(1);
     });
   });
 });

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -17,16 +17,16 @@ export class ProjectComponent implements OnInit {
   public showFilters: boolean;
   public filter = '';
   public propfilter = '';
-  public proponentListFilter: '';
-  public phasefilter: '';
-  public projectPhaseFilter: '';
-  public projectTypeFilter: '';
-  public filterType: '';
-  public projectDecisionFilter: '';
-  public filterDecision: '';
-  public projectStatusFilter: '';
-  public filterStatus: '';
-  public filterPCP: '';
+  public proponentListFilter = '';
+  public phasefilter = '';
+  public projectPhaseFilter = '';
+  public projectTypeFilter = '';
+  public filterType = '';
+  public projectDecisionFilter = '';
+  public filterDecision = '';
+  public projectStatusFilter = '';
+  public filterStatus = '';
+  public filterPCP = '';
   public isDesc: boolean;
   public column: string;
   public direction: number;
@@ -89,5 +89,6 @@ export class ProjectComponent implements OnInit {
     this.phasefilter = undefined;
     this.projectPhaseFilter = undefined;
     this.filterPCP = undefined;
+    this.config.currentPage = 1;
   }
 }


### PR DESCRIPTION
It looks like the changes to _ngModel_ are not detected by the view when triggered by a function in the component, so I had to explicitly reset the pagination index.

Review includes change + updated tests.