### PR TITLE
[EM-977] Fixing Alert in Submit Comment Interface

### DIFF
--- a/src/app/comment-period/submit-comment-modal/submit-comment-modal.component.html
+++ b/src/app/comment-period/submit-comment-modal/submit-comment-modal.component.html
@@ -13,7 +13,12 @@
   <form #f="ngForm" [hidden]="loading" (ngSubmit)="onSubmit(f.value)" id="submitCommentForm" novalidate>
     <div class="modal-body submit-comment-form">
       <div class="alert alert-danger" *ngIf="error">
-        <strong>Danger!</strong> Indicates a dangerous or potentially negative action.
+        <span class="alert__icon">
+          <i class="material-icons">
+              error
+          </i>
+        </span>
+        <span class="alert__msg">An error occurred while attempting to submit your comment. Please try again later.</span>
       </div>
       <div class="form-group">
         <label class="form-control-label" for="author">Your Name <em>(Required)</em></label>
@@ -30,7 +35,7 @@
       <div class="form-group">
         <label class="mb-0 form-control-label" for="file">Upload Attachments</label>
         <span class="form-text mt-0">Total uploads Cannot exceed 5MB. Accepted file types: pdf, png, gif, jpg, jpeg, bmp</span>
-        <ul class="file__list mt-2 mb-3" *ngIf="files.length > 0">
+        <ul class="file__list mt-3" *ngIf="files.length > 0">
           <li class="file__list-item" *ngFor="let file of files">
             <span class="file__list-item-icon">
               <i class="material-icons">&#xE2BC;</i>
@@ -45,7 +50,7 @@
             </span>
           </li>
         </ul>
-        <div class="file-upload mt-2">
+        <div class="file-upload mt-3">
           <input type="file" class="form-control" id="file" name="file" size="5000000" accept=".pdf, .png, .gif, .jpg., .jpeg, .bmp" (change)="onFileChange($event, f.value)" multiple [(ngModel)]="comment.documents" #documents="ngModel">
           <div class="file-upload__target">
             <span class="file-upload__prompt">

--- a/src/app/comment-period/submit-comment-modal/submit-comment-modal.component.scss
+++ b/src/app/comment-period/submit-comment-modal/submit-comment-modal.component.scss
@@ -1,5 +1,6 @@
 @import "~assets/styles/base.scss";
 @import "~assets/styles/helpers/mixins.scss";
+@import "~assets/styles/components/alerts.scss";
 @import "~assets/styles/components/file-list.scss";
 @import "~assets/styles/components/file-upload.scss";
 @import "~assets/styles/components/modals.scss";

--- a/src/app/comment-period/submit-comment-modal/submit-comment-modal.ts
+++ b/src/app/comment-period/submit-comment-modal/submit-comment-modal.ts
@@ -171,5 +171,6 @@ export class SubmitCommentModalComponent implements OnInit {
     step2.classList.add('hidden');
     step3.classList.add('hidden');
 
+    this.error = false;
   }
 }

--- a/src/assets/styles/components/alerts.scss
+++ b/src/assets/styles/components/alerts.scss
@@ -1,0 +1,26 @@
+$alert-danger-color:  #fff;
+$alert-danger-bg:     red;
+
+.alert {
+  @include flex-box();
+  line-height: 1rem;
+  font-size: 0.9375rem;
+
+  &__icon {
+    @include flex(0 0 auto);
+    margin-top: -0.1rem;
+    margin-right: 0.75rem;
+  }
+
+  &__msg {
+    @include flex(1 1 auto);
+    line-height: 1.25rem;
+    font-size: 0.9375rem;
+  }
+}
+
+.alert-danger {
+  border-color: $alert-danger-bg;
+  background-color: $alert-danger-bg;
+  color: $alert-danger-color;
+}

--- a/src/assets/styles/components/form-elements.scss
+++ b/src/assets/styles/components/form-elements.scss
@@ -77,3 +77,19 @@ textarea {
 	font-size: 0.9375rem;
 	resize: vertical;
 }
+
+.has-danger {
+	label {
+		em {
+			color: inherit;
+		}
+	}
+
+	.form-text {
+		color: $fc-invalid-color;
+	}
+
+	.form-control {
+		background-color: $fc-invalid-bg;
+	}
+}

--- a/src/assets/styles/themes/default.scss
+++ b/src/assets/styles/themes/default.scss
@@ -56,6 +56,8 @@ $fc-bg:                         #fff;
 $fc-inner-shadow:               0.1rem 0.1rem 0.1rem #eee;
 $fc-placeholder-color:          #999;
 $fc-focus-border-color:         #5091cd;
+$fc-invalid-color:              #d9534f;
+$fc-invalid-bg:                 #ffffd8;
 
 // List Variants
 $nv-list-bg:                    #f7f8fa;


### PR DESCRIPTION
- Added a generic message to the alert
- Added iconography
- Alert message will now not be visible when a user has cancelled a failed submission attempt and reopened the interface