### PR TITLE
[EM-1017] Fixed Wrapping issue in news and announcments

### DIFF
--- a/src/assets/styles/components/activity-feed.scss
+++ b/src/assets/styles/components/activity-feed.scss
@@ -138,7 +138,7 @@ $activity-feed-date-column-width: 10rem;
     margin: 0;
     overflow: hidden;
     font-size: 100%;
-    white-space: pre;
+    white-space: pre-wrap;
   }
 
   &__link {


### PR DESCRIPTION
Added the correct white-space property so text will wrap as normal AND with line breaks. (previous property will only wrap on line breaks).