### PR TITLE
bugfix: deprecated dependency possibly breaking openshift build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jquery": "3.3.1",
     "lodash": "4.17.10",
     "mygovbc-bootstrap-theme": "0.4.1",
-    "ng2-page-scroll": "4.0.0-beta.12",
+    "ngx-page-scroll": "4.0.2",
     "ngx-filesize": "1.1.2",
     "ngx-order-pipe": "1.0.4",
     "ngx-pagination": "3.0.3",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { HttpModule } from '@angular/http';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Ng2PageScrollModule, PageScrollConfig } from 'ng2-page-scroll';
+import { NgxPageScrollModule, PageScrollConfig } from 'ngx-page-scroll';
 import { AppComponent } from './app.component';
 import { Api } from './services/api';
 
@@ -21,7 +21,7 @@ describe('AppComponent', () => {
       imports: [
         RouterTestingModule,
         HttpModule,
-        Ng2PageScrollModule.forRoot()
+        NgxPageScrollModule
       ]
     }).compileComponents();
   });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { PageScrollConfig } from 'ng2-page-scroll';
+import { PageScrollConfig } from 'ngx-page-scroll';
 import { Api } from './services/api';
 import { EmailService } from './services/email.service';
 import { NewsService } from './services/news.service';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { HttpModule } from '@angular/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { Ng2PageScrollModule } from 'ng2-page-scroll';
+import { NgxPageScrollModule } from 'ngx-page-scroll';
 import { NgxPaginationModule } from 'ngx-pagination';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -44,7 +44,7 @@ import { SharedModule } from './shared/shared.module';
     CommentPeriodModule,
     FormsModule,
     HttpModule,
-    Ng2PageScrollModule.forRoot(),
+    NgxPageScrollModule,
     NgbModule,
     NgxPaginationModule,
     MapModule,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4404,10 +4404,6 @@ next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
-ng2-page-scroll@4.0.0-beta.12:
-  version "4.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/ng2-page-scroll/-/ng2-page-scroll-4.0.0-beta.12.tgz#26b4e71ef9ad0859f1fa4e5e8d6ce7c75b73c6f7"
-
 ngx-filesize@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ngx-filesize/-/ngx-filesize-1.1.2.tgz#d107d236cde364bc86ba48678787ab2003edd6e7"
@@ -4417,6 +4413,10 @@ ngx-filesize@1.1.2:
 ngx-order-pipe@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/ngx-order-pipe/-/ngx-order-pipe-1.0.4.tgz#f71775ad1543aef2bb507fb79425866dd4d3c641"
+
+ngx-page-scroll@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/ngx-page-scroll/-/ngx-page-scroll-4.0.2.tgz#0b1b7f26f48f2d55356a19023490052e9fa5a8d9"
 
 ngx-pagination@3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Updated ng2-page-scroll, which has been deprecated and renamed, to ngx-page-scroll