### PR TITLE
HOTFIX: Browse all documents link location fix

### DIFF
--- a/src/app/project-detail/project-detail.component.html
+++ b/src/app/project-detail/project-detail.component.html
@@ -37,6 +37,12 @@
                 </section>
               </div>
               <div class="activity-feed">
+                <section class="card">
+                  <div class="card-body">
+                    <p class="mb-0">Looking for more detailed information?
+                    <a href="{{getDocumentManagerUrl()}}" target="_blank">Browse all documentation</a> for this project.</p>
+                  </div>
+                </section>
                 <div class="spinner-container relative mt-4" [hidden]="!loading">
                   <div class="spinner-new--sm rotating"></div>
                 </div>
@@ -75,12 +81,6 @@
                     </div>
                   </div>
                   <ng-container>
-                    <section class="card">
-                      <div class="card-body">
-                        <p class="mb-0">Looking for more detailed information?
-                          <a href="{{getDocumentManagerUrl()}}" target="_blank">Browse all documentation</a> for this project.</p>
-                      </div>
-                    </section>
                     <pagination-template class="pagination--top mb-2" #p="paginationApi" [id]="config.id" (pageChange)="config.currentPage = $event">
                       <span [hidden]="filteredResults <= 0" class="pagination__result-count" [innerHTML]="getDisplayedElementCountMessage(p.getCurrent())"></span>
                       <span [hidden]="filteredResults > 0" class="pagination__result-count">No results found</span>


### PR DESCRIPTION
Changed the location of the browse all documents link so that it appears even with no activities and updates found