### PR TITLE
Fix for git change detection

### DIFF
--- a/. gitattributes
+++ b/. gitattributes
@@ -1,19 +1,34 @@
 # Auto detect text files and perform LF normalization
 * text eol=lf
-*.bat text eol=crlf
+*.[bB][aA][tT] text eol=crlf
 
-# Binary files
+# Binary archive files
 # ============
-*.png binary
-*.svg binary
-*.gz binary
-*.jar       binary
-*.jpg       binary
-*.jpeg      binary
-*.ico       binary
-*.tif       binary
-*.tiff      binary
-*.eot       binary
-*.ttf       binary
-*.woff      binary
-*.min.js.gzip      binary
+*.[gG][zZ] binary
+*.[jJ][aA][rR] binary
+*.[mM][iM][nN].[jJ][sS].[gG][zZ][iI][pP] binary
+
+# Binary font files
+# ============
+*.[eE][oO][tT] binary
+*.[tT][tT][fF] binary
+*.[wW][oO][fF][fF] binary
+*.[wW][oO][fF][fF]2 binary
+
+# Binary image files
+# ============
+*.[iI][cC][oO] binary
+*.[jJ][pP][gG] binary
+*.[jJ][pP][eE][gG] binary
+*.[pP][nN][gG] binary
+*.[sS][vV][gG] binary
+*.[tT][iI][fF] binary
+*.[tT][iI][fF][fF] binary
+
+# Binary text files
+# ============
+*.[dD][oO][cC] binary
+*.[dD][oO][cC][xX] binary
+*.[xX][lL][sS] binary
+*.[xX][lL][sS][xX] binary
+*.[pP][dD][fF] binary


### PR DESCRIPTION
This is meant to solve 2 problems.  

The first is for developers working on Windows and Macs, these systems handle file endings differently and git will sometime go and "fix" files unnecessarily.  These settings tell git explicitly what to ignore for file endings so that it behaves consistently across systems.

Secondly, this change also corrects some syntactical issues with the file itself and uses a consistent format.  It also accounts for different casing in file extensions.